### PR TITLE
Add KategoriSoal model and update Penjadwalan relationships to use KategoriSoal

### DIFF
--- a/app/Models/KategoriSoal.php
+++ b/app/Models/KategoriSoal.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class KategoriSoal extends Model
+{
+    protected $connection = 'data_db';
+    protected $table = 't_kat_soal';
+    protected $primaryKey = 'id';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'id',
+        'kategori',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}

--- a/app/Models/Penjadwalan.php
+++ b/app/Models/Penjadwalan.php
@@ -39,10 +39,10 @@ class Penjadwalan extends Model
         'jenis_ujian' => 'integer',
     ];
 
-    // tipe_ujian is kode from mbidang
+    // tipe_ujian is id from t_kat_soal
     public function jenis_ujian()
     {
-        return $this->belongsTo(MBidang::class, 'tipe_ujian', 'kode');
+        return $this->belongsTo(KategoriSoal::class, 'tipe_ujian', 'id');
     }
 
     /**
@@ -58,19 +58,19 @@ class Penjadwalan extends Model
     {
         // If jenis_ujian is an integer (likely jenis_ujian field being used instead of relation)
         if (isset($this->attributes['tipe_ujian']) && is_int($this->attributes['tipe_ujian'])) {
-            $mbidang = MBidang::find($this->attributes['tipe_ujian']);
-            return $mbidang ? $mbidang->nama : (string)$this->attributes['tipe_ujian'];
+            $kategoriSoal = KategoriSoal::find($this->attributes['tipe_ujian']);
+            return $kategoriSoal ? $kategoriSoal->kategori : (string)$this->attributes['tipe_ujian'];
         }
 
-        // Load the related MBidang model and get its name
+        // Load the related KategoriSoal model and get its kategori
         if ($this->relationLoaded('jenis_ujian') && $this->jenis_ujian) {
-            return $this->jenis_ujian->nama;
+            return $this->jenis_ujian->kategori;
         }
 
         // If relation is not loaded, try to load it
         if (isset($this->attributes['tipe_ujian'])) {
-            $mbidang = MBidang::where('kode', $this->attributes['tipe_ujian'])->first();
-            return $mbidang ? $mbidang->nama : (string)$this->attributes['tipe_ujian'];
+            $kategoriSoal = KategoriSoal::where('id', $this->attributes['tipe_ujian'])->first();
+            return $kategoriSoal ? $kategoriSoal->kategori : (string)$this->attributes['tipe_ujian'];
         }
 
         return '';


### PR DESCRIPTION
This pull request introduces a new model, `KategoriSoal`, and updates the `Penjadwalan` model to use it instead of the `MBidang` model for handling the `tipe_ujian` field. The changes improve the data structure and relationships for better alignment with the database schema.

### Addition of the `KategoriSoal` model:
* [`app/Models/KategoriSoal.php`](diffhunk://#diff-87492fc1fc131bb07b9a23d5d54c7d76c05d1c0e252c16a8f86d75e2776dfa1fR1-R22): Added a new model, `KategoriSoal`, with a connection to the `data_db` database, mapping to the `t_kat_soal` table. This model includes fillable attributes (`id`, `kategori`) and type casting for the `id` field.

### Updates to the `Penjadwalan` model:
* [`app/Models/Penjadwalan.php`](diffhunk://#diff-5704d21ad8380147a465a0a883feeb96b193933f7d1e047c03476536a8224d66L42-R45): Updated the `jenis_ujian` relationship to use the new `KategoriSoal` model instead of `MBidang`. This change aligns the `tipe_ujian` field with the `id` column in the `t_kat_soal` table.
* [`app/Models/Penjadwalan.php`](diffhunk://#diff-5704d21ad8380147a465a0a883feeb96b193933f7d1e047c03476536a8224d66L61-R73): Modified the `getTipeUjianAttribute` method to retrieve data from the `KategoriSoal` model, replacing references to `MBidang`. This includes updates to handle both loaded relationships and direct attribute access.