### PR TITLE
feat: Update kategori soal API endpoint and add dropdown route

### DIFF
--- a/resources/js/pages/banksoalcreate.tsx
+++ b/resources/js/pages/banksoalcreate.tsx
@@ -106,7 +106,7 @@ export default function BankSoalCreate() {
     useEffect(() => {
         const fetchKategoriOptions = async () => {
             try {
-                const res = await axios.get('/master-data/kategorisoal');
+                const res = await axios.get('/master-data/kategori-soal-dropdown');
                 console.log('Kategori Soal response:', res.data); // Tambahkan logging
                 setKategoriOptions(res.data);
             } catch (error) {

--- a/resources/js/pages/banksoaledit.tsx
+++ b/resources/js/pages/banksoaledit.tsx
@@ -180,7 +180,7 @@ export default function BankSoalEdit({ soal }: { soal: SoalForm }) {
         // Add new fetch for kategori options
         const fetchKategoriOptions = async () => {
             try {
-                const res = await axios.get('/master-data/kategorisoal');
+                const res = await axios.get('/master-data/kategori-soal-dropdown');
                 console.log('Kategori Soal response:', res.data);
                 setKategoriOptions(res.data);
             } catch (error) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -150,7 +150,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::delete('bank-soal/{id}', [BankSoalController::class, 'destroy'])->name('bank.soal.destroy');
 
         // Route edit bank soal
-        Route::put('bank-soal/update/{id}', [BankSoalController::class, 'update'])->name('bank.soal.update');
+        Route::put('bank-soal/{id}', [BankSoalController::class, 'update'])->name('bank.soal.update');
         Route::get('bank-soal/{id}/edit', [BankSoalController::class, 'edit'])->name('bank.soal.edit');
 
         // Route tambah bank soal
@@ -208,7 +208,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         });
 
         // Route untuk kategori soal
-        Route::prefix('kategori-soal')->name('master-data.kategori-soal.')->group(function () {
+        Route::prefix('kategori-soal')->name('kategori-soal.')->group(function () {
             Route::get('/', [KategoriUjianController::class, 'index'])->name('index');
             Route::get('/create', [KategoriUjianController::class, 'create'])->name('create');
             Route::post('/', [KategoriUjianController::class, 'store'])->name('store');
@@ -216,6 +216,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
             Route::put('/{id}', [KategoriUjianController::class, 'update'])->name('update');
             Route::delete('/{id}', [KategoriUjianController::class, 'destroy'])->name('destroy');
         });
+        Route::get('/kategori-soal-dropdown', [KategoriUjianController::class, 'getKategoriList'])
+            ->name('kategori-soal.dropdown');
 
         Route::get('/bank-soal-checkbox/{paket_soal}/edit', [BankSoalControllerCheckbox::class, 'edit'])->name('bank-soal-checkbox.edit');
         Route::put('/bank-soal-checkbox/{paket_soal}', [BankSoalControllerCheckbox::class, 'update'])->name('bank-soal-checkbox.update');


### PR DESCRIPTION
This pull request includes updates to improve the handling of "Kategori Soal" data and refactors routes for better consistency and functionality. The most important changes involve modifying API endpoints used in the frontend, updating route definitions in the backend, and adding a new route to fetch dropdown options for "Kategori Soal."

### Frontend Updates:
* Changed the API endpoint for fetching "Kategori Soal" options in `BankSoalCreate` and `BankSoalEdit` components to use `/master-data/kategori-soal-dropdown` instead of `/master-data/kategorisoal`. This ensures compatibility with the newly added backend route. [[1]](diffhunk://#diff-d9c05a4ef653f238772d8bf7de002ce5735dbe09bbdca2e589897ada2b7ca767L109-R109) [[2]](diffhunk://#diff-7a5ed5743d9ef2de275f57c7637f25fede72816cf48a580ae5e224d4f51221dbL183-R183)

### Backend Route Updates:
* Refactored the `update` route for "Bank Soal" to remove the redundant `update` keyword in the URL, simplifying it to `bank-soal/{id}`.
* Updated the prefix and naming convention for "Kategori Soal" routes to remove the `master-data` prefix, making the naming more concise and consistent.
* Added a new route `/kategori-soal-dropdown` to fetch the list of "Kategori Soal" options, supporting the frontend dropdown functionality.